### PR TITLE
Include BMI examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,46 +15,10 @@ RUN conda install -y \
     pkg-config \
     "numpy<2" \
     vim \
+    bmi-c \
+    bmi-cxx \
+    bmi-fortran \
+    bmipy \
     && conda clean --all -y
-
-ENV base_url=https://github.com/csdms
-
-ENV project=bmi-c
-ENV version="2.1.2"
-ENV prefix=/opt/${project}
-RUN git clone --branch v${version} ${base_url}/${project} ${prefix}
-WORKDIR ${prefix}/_build
-RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} && \
-    make && \
-    make install && \
-    make clean
-
-ENV project=bmi-cxx
-ENV version="2.0.2"
-ENV prefix=/opt/${project}
-RUN git clone --branch v${version} ${base_url}/${project} ${prefix}
-WORKDIR ${prefix}/_build
-RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} && \
-    make && \
-    make install && \
-    make clean
-
-ENV project=bmi-fortran
-ENV version="2.0.3"
-ENV prefix=/opt/${project}
-RUN git clone --branch v${version} ${base_url}/${project} ${prefix}
-WORKDIR ${prefix}/_build
-RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} && \
-    make && \
-    make install && \
-    make clean
-
-ENV project=bmi-python
-ENV version="2.0.1"
-ENV prefix=/opt/${project}
-RUN git clone --branch v${version} ${base_url}/${project} ${prefix}
-WORKDIR ${prefix}
-RUN pip install . && \
-    pip cache purge
 
 WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN conda install -y \
     cxx-compiler \
     fortran-compiler \
     pkg-config \
-    "numpy<2" \
+    numpy \
     vim \
     bmi-c \
     bmi-cxx \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Build the C, C++, Fortran, and Python BMI mappings in a Miniforge (Linux/Ubuntu) image.
+# Build the C, C++, Fortran, and Python BMI mappings and examples in a Miniforge (Linux/Ubuntu) image.
 FROM condaforge/miniforge3:25.3.0-3
 
 LABEL org.opencontainers.image.authors="Mark Piper <mark.piper@colorado.edu>"
@@ -20,5 +20,48 @@ RUN conda install -y \
     bmi-fortran \
     bmipy \
     && conda clean --all -y
+
+ENV base_url=https://github.com/csdms
+
+ENV project=bmi-example-c
+ENV version="2.0.3"
+ENV prefix=/opt/${project}
+RUN git clone --branch v${version} --depth 1 ${base_url}/${project} ${prefix}
+WORKDIR ${prefix}/_build
+RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} && \
+    make && \
+    make test && \
+    make install && \
+    make clean
+
+ENV project=bmi-example-cxx
+ENV version="2.1.3"
+ENV prefix=/opt/${project}
+RUN git clone --branch v${version} --depth 1 ${base_url}/${project} ${prefix}
+WORKDIR ${prefix}/_build
+RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} && \
+    make && \
+    make test && \
+    make install && \
+    make clean
+
+ENV project=bmi-example-fortran
+ENV version="2.1.4"
+ENV prefix=/opt/${project}
+RUN git clone --branch v${version} --depth 1 ${base_url}/${project} ${prefix}
+WORKDIR ${prefix}/_build
+RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} && \
+    make && \
+    make test && \
+    make install && \
+    make clean
+
+ENV project=bmi-example-python
+ENV version="2.1.2"
+ENV prefix=/opt/${project}
+RUN git clone --branch v${version} --depth 1 ${base_url}/${project} ${prefix}
+WORKDIR ${prefix}
+RUN pip install . && \
+    pip cache purge
 
 WORKDIR /opt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bmi-docker
 
-The [Basic Model Interface](https://bmi.csdms.io) (BMI) mappings for C, C++, Fortran, and Python, Dockerized.
+The [Basic Model Interface](https://bmi.csdms.io) (BMI) mappings and examples for C, C++, Fortran, and Python, Dockerized.
 
 The image built from these instructions can be used as a base for building models that expose a BMI in these languages,
 or for inter-language model coupling.
@@ -13,16 +13,86 @@ docker build --tag bmi .
 ```
 The image is built on the [condaforge/miniforge3](https://hub.docker.com/r/condaforge/miniforge3/) base image.
 The OS is Linux/Ubuntu.
-`conda`, as well as the BMI language mappings, are installed in `CONDA_DIR=/opt/conda`.
+`conda`, as well as the BMI language mappings and examples, are installed in `CONDA_DIR=/opt/conda`.
 The *base* environment is activated.
 
 ## Run a container
 
 Run a container from this image interactively:
 ```
-docker run -it bmi
+docker run -it --rm bmi
 ```
-This starts a bash shell in the container where the language mappings can be accessed.
+This starts a bash shell in the container where the language mappings and examples can be accessed.
+
+### C example
+
+Run the program `run_bmiheatc`
+from the [BMI C example](https://github.com/csdms/bmi-example-c)
+with a configuration file:
+```bash
+cd /tmp
+echo "1.5, 8.0, 6, 5" > config.txt
+run_bmiheatc config.txt
+```
+View the program's output with:
+```bash
+cat bmiheatc.out
+```
+
+### C++ example
+
+Run the program `run_bmiheatcxx`
+from the [BMI C++ example](https://github.com/csdms/bmi-example-cxx)
+with a configuration file:
+```bash
+cd /tmp
+echo "1.5, 8.0, 6, 5" > config.txt
+run_bmiheatcxx config.txt
+```
+View the program's output with:
+```bash
+cat bmiheatcxx.out
+```
+
+### Fortran example
+
+Run the program `run_bmiheatf`
+from the [BMI Fortran example](https://github.com/csdms/bmi-example-fortran)
+with a configuration file:
+```bash
+cd /tmp
+echo "1.5, 8.0, 6, 5" > config.txt
+run_bmiheatf config.txt
+```
+View the program's output with:
+```bash
+cat bmiheatf.out
+```
+
+### Python example
+
+Start a Python session to run the *heat* model through its BMI.
+```python
+>>> from heat import BmiHeat
+>>> x = BmiHeat()
+>>> x.get_component_name()
+'The 2D Heat Equation'
+```
+
+The Python BMI example includes a set of [example notebooks](https://github.com/csdms/bmi-example-python/tree/master/examples).
+Run them through a container.
+```bash
+docker run -it --port 8888:8888 bmi-example-python /bin/bash -c "\
+    conda install jupyter -y --quiet && \
+    jupyter notebook \
+    --notebook-dir=/opt/bmi-example-python/examples \
+    --ip='*' --port=8888 \
+    --no-browser --allow-root"
+```
+This is a little tricky, but
+examine the output of the Jupyter server after it starts;
+it will include an URL from *localhost* that includes a security token.
+Copy/paste this URL into a browser to view and run the example notebooks.
 
 ## Developer notes
 


### PR DESCRIPTION
Rather than building a separate image with the BMI examples (C, C++, Fortran, and Python), build them here alongside the mappings. This saves about 1.8 GB from having a separate image.

This will obsolete the [csdms/bmi-examples-docker](https://github.com/csdms/bmi-examples-docker) repository and the image built from it on Docker Hub.